### PR TITLE
recoded regexp-based replaces to use the new features available with PHP7

### DIFF
--- a/edit_area/edit_area_compressor.php
+++ b/edit_area/edit_area_compressor.php
@@ -143,12 +143,12 @@
 			$loader= $this->get_content("edit_area_loader.js")."\n";
 			
 			// get the list of other files to load
-	    	$loader= preg_replace("/(t\.scripts_to_load=\s*)\[([^\]]*)\];/e"
-						, "\$this->replace_scripts('script_list', '\\1', '\\2')"
+	    	$loader= preg_replace_callback("/(t\.scripts_to_load=\s*)\[([^\]]*)\];/"
+            , function ($matches) { return $this->replace_scripts('script_list', $matches[1], $matches[2]);}
 						, $loader);
 		
-			$loader= preg_replace("/(t\.sub_scripts_to_load=\s*)\[([^\]]*)\];/e"
-						, "\$this->replace_scripts('sub_script_list', '\\1', '\\2')"
+			$loader= preg_replace_callback("/(t\.sub_scripts_to_load=\s*)\[([^\]]*)\];/"
+						, function ($matches) { return $this->replace_scripts('sub_script_list', $matches[1], $matches[2]);}
 						, $loader);
 
 			// replace languages names


### PR DESCRIPTION

Since PHP 5.5, the '/e' modifier for regexps has been deprecated, which is safe since it previously
called an eval loop, whith difficult to predict consequences.

The replacement uses a closure function, which make the operations more readable by developers.

I made the change since I am including the source of edit_area into the Debian package wims (see https://packages.qa.debian.org/w/wims.html and https://qa.debian.org/developer.php?login=georgesk@debian.org#wims)

Official Debian packages must be compiled from sources with no obfuscated file and no binaries, so
the file edit_area_compressor.php must be used to generate the "binary file" edit_area_full.js

If you like, I can publish a separate Debian package for edit_area, would you?

Please accept this pull request, so I shall need less patches in the future, for next releases of wims.